### PR TITLE
Fixed typo in section about remote-syslog

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -1069,7 +1069,7 @@ fluent-plugin-remote-syslog gem
 | The default is set to `false`.  Set to `true` to use the record's severity
 and facility fields to set on the syslog message
 
-|`openshift_logging_fluentd_remote_syslog_remote_tag_prefix`
+|`openshift_logging_fluentd_remote_syslog_remove_tag_prefix`
 | Removes the prefix from the tag, defaults to `''` (empty)
 
 |`openshift_logging_fluentd_remote_syslog_tag_key`
@@ -1107,7 +1107,7 @@ fluent-plugin-remote-syslog gem
 | The default is set to `false`.  Set to `true` to use the record's severity
 and facility fields to set on the syslog message
 
-|`openshift_logging_mux_remote_syslog_remote_tag_prefix`
+|`openshift_logging_mux_remote_syslog_remove_tag_prefix`
 | Removes the prefix from the tag, defaults to `''` (empty)
 
 |`openshift_logging_mux_remote_syslog_tag_key`


### PR DESCRIPTION
The parameter should be REMOVE_TAG_PREFIX, not REMOTE_TAG_PREFIX.

I verified that this is just a documentation bug, the code is correct.